### PR TITLE
Fixed: Container parameter in twoFingers ignored

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,12 @@ export const twoFingers = (
   let gesture: Gesture | undefined = undefined;
   let timer: number;
 
-  const wheelListener = (event: WheelEvent) => {
+  const wheelListener = (event: Event) => {
+    if (!(event instanceof WheelEvent)) {
+      console.error("Expected WheelEvent, got", event);
+      return;
+    }
+
     event.preventDefault();
 
     const { dx, dy } = normalizeWheelEvent(event);
@@ -149,7 +154,7 @@ export const twoFingers = (
     }
   };
 
-  document.addEventListener("wheel", wheelListener, { passive: false });
+  container.addEventListener("wheel", wheelListener, { passive: false });
   container.addEventListener("touchstart", watchTouches, { passive: false });
 
   /*
@@ -194,7 +199,7 @@ export const twoFingers = (
   }
 
   return () => {
-    document.removeEventListener("wheel", wheelListener);
+    container.removeEventListener("wheel", wheelListener);
     container.removeEventListener("touchstart", watchTouches);
 
     if (typeof window.GestureEvent !== "undefined" && typeof window.TouchEvent === "undefined") {


### PR DESCRIPTION
Previously, the event listener for the wheel event was on the document, causing the scroll to ignore the container element in the constructor. This fixes it by listening only to the scroll events of the container specified in the constructor of twoFingers.