### PR TITLE
Add reference normalize wheel implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,12 @@ export const twoFingers = (
   let gesture: Gesture | undefined = undefined;
   let timer: number;
 
-  const wheelListener = (event: WheelEvent) => {
+  const wheelListener = (event: Event) => {
+    if (!(event instanceof WheelEvent)) {
+      console.error("Expected WheelEvent, got", event);
+      return;
+    }
+
     event.preventDefault();
 
     const { dx, dy } = normalizeWheelEvent(event);
@@ -149,7 +154,7 @@ export const twoFingers = (
     }
   };
 
-  document.addEventListener("wheel", wheelListener, { passive: false });
+  container.addEventListener("wheel", wheelListener, { passive: false });
   container.addEventListener("touchstart", watchTouches, { passive: false });
 
   /*
@@ -194,7 +199,7 @@ export const twoFingers = (
   }
 
   return () => {
-    document.removeEventListener("wheel", wheelListener);
+    container.removeEventListener("wheel", wheelListener);
     container.removeEventListener("touchstart", watchTouches);
 
     if (typeof window.GestureEvent !== "undefined" && typeof window.TouchEvent === "undefined") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,39 @@ export const clientToSVGElementCoords = (el: SVGSVGElement, coords: Coords): Coo
   return point.matrixTransform(screenToElement);
 };
 
+function limit(delta: number, max_delta: number) {
+  return Math.sign(delta) * Math.min(max_delta, Math.abs(delta));
+}
+
+function normalizeWheel(e: WheelEvent) {
+  const DELTA_LINE_MULTIPLIER = 8;
+  const DELTA_PAGE_MULTIPLIER = 24;
+  const MAX_WHEEL_DELTA = 24;
+  
+  let dx = e.deltaX;
+  let dy = e.deltaY;
+  
+  if (e.shiftKey && dx === 0) {
+    [dx, dy] = [dy, dx];
+  }
+  
+  if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    dx *= DELTA_LINE_MULTIPLIER;
+    dy *= DELTA_LINE_MULTIPLIER;
+  } else if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    dx *= DELTA_PAGE_MULTIPLIER;
+    dy *= DELTA_PAGE_MULTIPLIER;
+  }
+  return {
+    dx: limit(dx, MAX_WHEEL_DELTA),
+    dy: limit(dy, MAX_WHEEL_DELTA),
+  };
+}
+
 export const twoFingers = (
   container: Element,
   { onGestureStart, onGestureChange, onGestureEnd }: GestureCallbacks = {},
-  normalizeWheelEvent: (event: WheelEvent) => NormalizedWheelEvent,
+  normalizeWheelEvent: (event: WheelEvent) => NormalizedWheelEvent = normalizeWheel,
 ): (() => void) => {
   // TODO: we shouldn't be reusing gesture
   let gesture: Gesture | undefined = undefined;


### PR DESCRIPTION
I had to find an implementation for normalizing the wheel event,  but think it should be included by default to make it easier for users of the library to get started. My implementation still allows overriding the default normalizeWheelEvent function.